### PR TITLE
Ensure up to sixteen Floating IPs can be assigned to a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ These tests are run regularly against our public infrastructure as well as our i
 | **Custom Image**    | [test_custom_image_with_slug](./test_custom_image.py#L11)                        | custom   |
 |                     | [test_custom_image_with_uuid](./test_custom_image.py#L22)                        | custom   |
 | **Floating IP**     | [test_floating_ip_connectivity](./test_floating_ip.py#L14)                       | default  |
-|                     | [test_floating_ip_stability](./test_floating_ip.py#L32)                          | default  |
-|                     | [test_floating_ip_failover](./test_floating_ip.py#L75)                           | default  |
-|                     | [test_floating_network](./test_floating_ip.py#L117)                              | default  |
+|                     | [test_multiple_floating_ips](./test_floating_ip.py#L32)                          | default  |
+|                     | [test_floating_ip_stability](./test_floating_ip.py#L54)                          | default  |
+|                     | [test_floating_ip_failover](./test_floating_ip.py#L97)                           | default  |
+|                     | [test_floating_network](./test_floating_ip.py#L139)                              | default  |
 | **Private Network** | [test_private_ip_address_on_all_images](./test_private_network.py#L14)           | all      |
 |                     | [test_private_network_connectivity_on_all_images](./test_private_network.py#L35) | all      |
 |                     | [test_multiple_private_network_interfaces](./test_private_network.py#L88)        | default  |

--- a/test_floating_ip.py
+++ b/test_floating_ip.py
@@ -29,6 +29,28 @@ def test_floating_ip_connectivity(prober, server, floating_ip):
     prober.ping(floating_ip, count=30, interval=0.5)
 
 
+def test_multiple_floating_ips(prober, server, create_floating_ip):
+    """ A server may have up to fifteen Floating IPs assigned to it. """
+
+    # Create and assign Floating IPs
+    ips = [
+        create_floating_ip(
+            ip_version=4,
+            server=server.uuid
+        ) for _ in range(15)
+    ]
+
+    # Configure the Floating IPs on the server
+    for ip in ips:
+        server.configure_floating_ip(ip)
+
+    # Make sure each Floating IP can be pinged from the prober
+    for ip in ips:
+
+        # Wait up to 15 seconds for the change to propagate
+        prober.ping(ip, timeout=1, tries=15)
+
+
 def test_floating_ip_stability(prober, create_server, server_group,
                                floating_ipv4, floating_ipv6):
     """ Floating IPs can be moved between servers for high availability.


### PR DESCRIPTION
Previously, the limit was set to ten - a limit which we did not yet verify using acceptance tests.