### PR TITLE
Schedule the nightly tests two hours earlier

### DIFF
--- a/.github/workflows/acceptance-tests-in-lpg1.yml
+++ b/.github/workflows/acceptance-tests-in-lpg1.yml
@@ -13,7 +13,7 @@ on:
 
   # Scheduled tests
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 0 * * *'
 
   # Manual execution through the UI by collaborators
   workflow_dispatch:

--- a/.github/workflows/acceptance-tests-in-rma1.yml
+++ b/.github/workflows/acceptance-tests-in-rma1.yml
@@ -13,7 +13,7 @@ on:
 
   # Scheduled tests
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 22 * * *'
 
   # Manual execution through the UI by collaborators
   workflow_dispatch:


### PR DESCRIPTION
GitHub's action scheduler can be off by a few hours. By scheduling the tests a
bit earlier, the likelihood of them being run at night is increased.