### PR TITLE
Check API response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ These tests are run regularly against our public infrastructure as well as our i
 | **Private Network** | [test_private_ip_address_on_all_images](./test_private_network.py#L14)           | all      |
 |                     | [test_private_network_connectivity_on_all_images](./test_private_network.py#L35) | all      |
 |                     | [test_multiple_private_network_interfaces](./test_private_network.py#L88)        | default  |
-|                     | [test_no_private_network_port_security](./test_private_network.py#L152)          | default  |
-|                     | [test_private_network_without_dhcp](./test_private_network.py#L208)              | default  |
-|                     | [test_private_network_mtu](./test_private_network.py#L251)                       | default  |
-|                     | [test_private_network_only_on_all_images](./test_private_network.py#L309)        | all      |
+|                     | [test_no_private_network_port_security](./test_private_network.py#L145)          | default  |
+|                     | [test_private_network_without_dhcp](./test_private_network.py#L201)              | default  |
+|                     | [test_private_network_mtu](./test_private_network.py#L244)                       | default  |
+|                     | [test_private_network_only_on_all_images](./test_private_network.py#L302)        | all      |
 | **Public Network**  | [test_public_ip_address_on_all_images](./test_public_network.py#L17)             | all      |
 |                     | [test_public_network_connectivity_on_all_images](./test_public_network.py#L46)   | all      |
 |                     | [test_public_network_mtu](./test_public_network.py#L65)                          | default  |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ These tests are run regularly against our public infrastructure as well as our i
 
 | Category            | Test Name                                                                        | Images   |
 |---------------------|----------------------------------------------------------------------------------|----------|
+| **API**             | [test_duplicate_headers](./test_api.py#L14)                                      | -        |
+|                     | [test_invalid_duplicate_headers](./test_api.py#L33)                              | -        |
+|                     | [test_cors_headers](./test_api.py#L58)                                           | -        |
 | **Custom Image**    | [test_custom_image_with_slug](./test_custom_image.py#L11)                        | custom   |
 |                     | [test_custom_image_with_uuid](./test_custom_image.py#L22)                        | custom   |
 | **Floating IP**     | [test_floating_ip_connectivity](./test_floating_ip.py#L14)                       | default  |

--- a/api.py
+++ b/api.py
@@ -40,7 +40,7 @@ class API(requests.Session):
     def __init__(self, scope, read_only=False):
         super().__init__()
 
-        self.api_url = API_URL.rstrip('/')
+        self.api_url = API_URL
         self.headers['Authorization'] = f'Bearer {API_TOKEN}'
         self.hooks = {'response': self.on_response}
         self.scope = scope

--- a/constants.py
+++ b/constants.py
@@ -19,7 +19,7 @@ if not os.environ.get('CLOUDSCALE_API_TOKEN'):
 #
 # See RUNNER_ID below.
 API_TOKEN = os.environ['CLOUDSCALE_API_TOKEN']
-API_URL = os.environ.get('CLOUDSCALE_API_URL', 'https://api.cloudscale.ch/v1/')
+API_URL = os.environ.get('CLOUDSCALE_API_URL', 'https://api.cloudscale.ch/v1')
 
 # One external ping target per IP version, that is assumed to be online
 PUBLIC_PING_TARGETS = {

--- a/tasks.py
+++ b/tasks.py
@@ -127,12 +127,16 @@ def implemented_tests_table(c):
     headers = ['Category', 'Test Name', 'Images']
     rows = []
 
+    # Special cases for capitalizing test category titles
+    category_capitalization = {
+        'floating ip': 'Floating IP',
+        'api': 'API',
+    }
+
     for module_path in sorted(Path('.').glob('test_*.py')):
         module = importlib.import_module(module_path.stem)
-        cat = module_path.stem.replace('test_', '').replace('_', ' ').title()
-
-        # There's no good rule for capitalizing this acronym
-        cat = cat.replace('Floating Ip', 'Floating IP')
+        cat = module_path.stem.replace('test_', '').replace('_', ' ')
+        cat = category_capitalization.get(cat, cat.title())
 
         functions = []
 
@@ -155,6 +159,10 @@ def implemented_tests_table(c):
                 image = 'all'
             elif 'common_images' in name:
                 image = 'common'
+            elif 'test_api.py' in file:
+                # API tests are not run against any image, they test basic API
+                # functionality
+                image = '-'
             else:
                 image = 'default'
 

--- a/test_api.py
+++ b/test_api.py
@@ -1,0 +1,75 @@
+"""
+
+API Functionality
+=================
+
+Test the basic API functionality independent of any specific API actions.
+
+"""
+import requests
+
+from constants import API_URL
+from util import raw_headers
+
+
+def test_duplicate_headers():
+    """ Check for duplicate headers (same key and value).
+
+    In general the same header field name may appear multiple times in a HTTP
+    response according to RFC 2616 section 4.2. But sending the exact same
+    header multiple times is always a misconfiguration. There is no need to
+    send the same value twice.
+
+    """
+
+    # Look for duplicate field values
+    for field_name, field_values in raw_headers(API_URL).items():
+        for value in field_values:
+            assert field_values.count(value) == 1
+
+
+def test_invalid_duplicate_headers():
+    """ Check there are no conflicting headers.
+
+    Only whitelisted header field names are allowed to appear multiple times
+    (with different values) in the response.
+
+    """
+
+    # List of header field names that are allowed multiple times
+    allowed_duplicate_field_names = (
+
+        # The "Vary" conditions may be influenced by different (reverse)
+        # proxies in the delivery chain.
+        'Vary',
+    )
+
+    # Each field name that has multiple values must be whitelisted
+    for field_name, field_values in raw_headers(API_URL).items():
+        if len(field_values) > 1:
+            assert field_name in allowed_duplicate_field_names
+
+
+def test_cors_headers():
+    """ Check for the correct list of CORS headers.
+
+    The API should allow CORS (Cross Origin Resource Sharing) to allow other
+    sites to embed the API. This is required for tools like Rancher to work
+    with our API. This must also work for non 20X status codes.
+
+    """
+
+    # Check CORS headers for a valid and invalid (HTTP 404) URL
+    for url in (API_URL, f'{API_URL}/invalid'):
+        headers = requests.get(url).headers
+
+        # Allow browsers to query the API from any origin
+        assert headers['Access-Control-Allow-Origin'] == '*'
+
+        # Allow Content-Type and Authorization headers
+        assert headers['Access-Control-Allow-Headers'] \
+            == 'Content-Type, Authorization'
+
+        # Allow all methods supported by the API
+        assert headers['Access-Control-Allow-Methods'] \
+            == 'GET, POST, OPTIONS, PUT, PATCH, DELETE'


### PR DESCRIPTION
This adds a new test module to test basic API functionality. It implements 4 tests in this module to check various aspects of the HTTP response headers. More tests for other aspects of the API can be added later.