### PR TITLE
Fix issues found testing Debian 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ These tests are run regularly against our public infrastructure as well as our i
 
 | Category            | Test Name                                                                        | Images   |
 |---------------------|----------------------------------------------------------------------------------|----------|
-| **API**             | [test_duplicate_headers](./test_api.py#L14)                                      | -        |
-|                     | [test_invalid_duplicate_headers](./test_api.py#L33)                              | -        |
-|                     | [test_cors_headers](./test_api.py#L58)                                           | -        |
+| **API**             | [test_duplicate_headers](./test_api.py#L15)                                      | -        |
+|                     | [test_invalid_duplicate_headers](./test_api.py#L31)                              | -        |
+|                     | [test_cors_headers](./test_api.py#L53)                                           | -        |
 | **Custom Image**    | [test_custom_image_with_slug](./test_custom_image.py#L11)                        | custom   |
 |                     | [test_custom_image_with_uuid](./test_custom_image.py#L22)                        | custom   |
 | **Floating IP**     | [test_floating_ip_connectivity](./test_floating_ip.py#L14)                       | default  |
 |                     | [test_multiple_floating_ips](./test_floating_ip.py#L32)                          | default  |
 |                     | [test_floating_ip_stability](./test_floating_ip.py#L54)                          | default  |
 |                     | [test_floating_ip_failover](./test_floating_ip.py#L97)                           | default  |
-|                     | [test_floating_network](./test_floating_ip.py#L139)                              | default  |
+|                     | [test_floating_network](./test_floating_ip.py#L140)                              | default  |
 | **Private Network** | [test_private_ip_address_on_all_images](./test_private_network.py#L14)           | all      |
 |                     | [test_private_network_connectivity_on_all_images](./test_private_network.py#L35) | all      |
 |                     | [test_multiple_private_network_interfaces](./test_private_network.py#L88)        | default  |
@@ -43,11 +43,11 @@ These tests are run regularly against our public infrastructure as well as our i
 |                     | [test_hostname](./test_server.py#L130)                                           | default  |
 |                     | [test_rename_server](./test_server.py#L148)                                      | default  |
 |                     | [test_reboot_server](./test_server.py#L172)                                      | default  |
-|                     | [test_stop_and_start_server](./test_server.py#L197)                              | default  |
-|                     | [test_rename_server_group](./test_server.py#L226)                                | default  |
-|                     | [test_no_cpu_steal_on_plus_flavor](./test_server.py#L236)                        | default  |
-|                     | [test_random_number_generator](./test_server.py#L268)                            | default  |
-|                     | [test_metadata_on_all_images](./test_server.py#L283)                             | all      |
+|                     | [test_stop_and_start_server](./test_server.py#L200)                              | default  |
+|                     | [test_rename_server_group](./test_server.py#L229)                                | default  |
+|                     | [test_no_cpu_steal_on_plus_flavor](./test_server.py#L239)                        | default  |
+|                     | [test_random_number_generator](./test_server.py#L272)                            | default  |
+|                     | [test_metadata_on_all_images](./test_server.py#L287)                             | all      |
 | **Volume**          | [test_attach_and_detach_volume_on_all_images](./test_volume.py#L22)              | all      |
 |                     | [test_expand_volume_online_on_all_images](./test_volume.py#L57)                  | all      |
 |                     | [test_expand_filesystem_online_on_common_images](./test_volume.py#L82)           | common   |

--- a/events.py
+++ b/events.py
@@ -256,6 +256,13 @@ track_in_event_log('server.wait-for-cloud-init.after', include={
     **RESULT,
 })
 
+track_in_event_log('server.wait-for-port.after', include={
+    **RESOURCE_ID,
+    **RESULT,
+    'port': 'args.port',
+    'state': 'args.state',
+})
+
 track_in_event_log('server.wait-for-non-tentative-ipv6.after', include={
     **RESOURCE_ID,
     **RESULT,

--- a/test_server.py
+++ b/test_server.py
@@ -187,6 +187,9 @@ def test_reboot_server(server):
     # Try to reboot through the shell
     server.run('sudo systemctl reboot')
 
+    # Wait for SSH to be unavailable, or we might re-connect prematurely
+    server.wait_for_port(22, 'offline', timeout=10)
+
     # Wait for the server to finish rebooting
     server.connect()
 

--- a/util.py
+++ b/util.py
@@ -1,6 +1,7 @@
 import atexit
 import os
 import re
+import socket
 import time
 import urllib
 
@@ -12,6 +13,7 @@ from constants import RESOURCE_CREATION_CONCURRENCY_LIMIT
 from constants import RESOURCE_NAME_PREFIX
 from constants import RUNTIME_PATH
 from constants import SERVER_START_TIMEOUT
+from contextlib import closing
 from contextlib import suppress
 from datetime import datetime, timedelta
 from errors import Timeout
@@ -509,3 +511,19 @@ def raw_headers(url, method="GET"):
         result[field_name].append(field_value)
 
     return result
+
+
+def is_port_online(host, port, timeout=1.0):
+    """ Returns true if the given TCP port is online. """
+
+    # Support server resources
+    if hasattr(host, 'ip'):
+        host = str(host.ip('public', 4))
+
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.settimeout(timeout)
+
+        try:
+            return sock.connect_ex((host, port)) == 0
+        except socket.gaierror:
+            return False


### PR DESCRIPTION
This merge request fixes two issues that were discovered with Debian 11, but could occur on other images as well:

1. Before reconnecting to a server after reboot, we need to wait for the server to actually power off.
2. The `dmidecode` utility should not be a requirement to calculate the present memory.

I've ran the updated tests against all images and against Debian 11 as a default.