### PR TITLE
Move the regular tests closer to our office hours

### DIFF
--- a/.github/workflows/acceptance-tests-in-lpg1.yml
+++ b/.github/workflows/acceptance-tests-in-lpg1.yml
@@ -11,9 +11,9 @@ on:
   #   explicit and change-specific way.
   #
 
-  # Scheduled tests
+  # Scheduled tests (UTC)
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 18 * * *'
 
   # Manual execution through the UI by collaborators
   workflow_dispatch:

--- a/.github/workflows/acceptance-tests-in-rma1.yml
+++ b/.github/workflows/acceptance-tests-in-rma1.yml
@@ -11,9 +11,9 @@ on:
   #   explicit and change-specific way.
   #
 
-  # Scheduled tests
+  # Scheduled tests (UTC)
   schedule:
-    - cron: '0 22 * * *'
+    - cron: '0 16 * * *'
 
   # Manual execution through the UI by collaborators
   workflow_dispatch:


### PR DESCRIPTION
It looks like GitHub is now able to schedule those tests quite accurately, when
in the past it was largely random.