### PR TITLE
Ensure ping function calls last as long as expected

### DIFF
--- a/resources.py
+++ b/resources.py
@@ -273,7 +273,7 @@ class Server(CloudscaleResource):
             self.wait_for_cloud_init(host, timeout)
 
         # Validate IPv6 if necessary
-        if self.spec['use_ipv6'] and self.spec.get('use_public_network'):
+        if self.spec['use_ipv6'] and self.has_public_interface:
             self.wait_for_non_tentative_ipv6()
             self.wait_for_ipv6_default_route()
 

--- a/resources.py
+++ b/resources.py
@@ -472,10 +472,26 @@ class Server(CloudscaleResource):
             error = f'ping failed on {self.name}'
 
         for n in range(1, tries + 1):
+            start = time.monotonic()
             cmd = self.run(f'{ping} {opts} {address}')
 
             if getattr(cmd, check):
                 return cmd.stdout
+
+            # The wait argument in this function is generally used to define an
+            # upper bound a ping check should take by the tests that call it.
+            #
+            # For example: ping(ip, wait=1, tries=10) is meant to ping an IP
+            # 10 times, for a total of up to 10 seconds.
+            #
+            # Ping's "-W" parameter does not work like that however. Depending
+            # on the scenario it won't wait at all. For example, if the
+            # network is unreachable, ping returns immediately.
+            #
+            # To correct for that, we add extra sleep to ensure that a ping
+            # "failure" causes the function to take as long as intended
+            # by the caller.
+            time.sleep(max(wait - (time.monotonic() - start), 0))
 
         raise AssertionError(f"{error}: {cmd.stdout}, {cmd.stderr}")
 


### PR DESCRIPTION
The assumption when writing tests was that ping would block for the given amount
of time, then retry. Where this assumption was violated, the tests would sometimes
fail randomly, as the wait was not long enough.