### PR TITLE
Add the ability to not use IPv6 in VMs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -97,6 +97,13 @@ def pytest_addoption(parser):
         help="Username used for custom images"
     )
 
+    parser.addoption(
+        '--no-ipv6',
+        action='store_true',
+        default=False,
+        help="Do not use IPv6 for VMs (tests that require it will fail)"
+    )
+
 
 def pytest_sessionstart(session):
     """ Processes the options and caches them for later use. """

--- a/resources.py
+++ b/resources.py
@@ -129,7 +129,7 @@ class Server(CloudscaleResource):
             'zone': self.request.config.option.zone,
             'volume_size_gb': 10,
             'use_public_network': True,
-            'use_ipv6': True,
+            'use_ipv6': not self.request.config.option.no_ipv6,
             'ssh_keys': self.request.getfixturevalue('all_public_keys'),
         }
 


### PR DESCRIPTION
This is only useful for testing and is therefore disabled by default.