### PR TITLE
Add test to deploy UEFI images and UEFI server

### DIFF
--- a/test_custom_image.py
+++ b/test_custom_image.py
@@ -33,7 +33,7 @@ def test_custom_image_with_uuid(create_server, custom_alpine_image):
 def test_custom_image_with_uefi(create_server, custom_ubuntu_uefi_image):
     """ Custom images with firmware type uefi can be used. """
 
-    # Create a image that uses bios firmware type
+    # Create an image that uses UEFI.
     image_uuid = custom_ubuntu_uefi_image.uuid
     server = create_server(image=image_uuid, username='ubuntu', use_ipv6=False)
 

--- a/test_custom_image.py
+++ b/test_custom_image.py
@@ -28,3 +28,15 @@ def test_custom_image_with_uuid(create_server, custom_alpine_image):
 
     # Make sure the server can be connected to.
     assert server.output_of('whoami') == 'alpine'
+
+
+def test_custom_image_with_uefi(create_server, custom_ubuntu_uefi_image):
+    """ Custom images with firmware type uefi can be used. """
+
+    # Create a image that uses bios firmware type
+    image_uuid = custom_ubuntu_uefi_image.uuid
+    server = create_server(image=image_uuid, username='ubuntu', use_ipv6=False)
+
+    # Make sure the server can be connected to.
+    assert server.output_of('whoami') == 'ubuntu'
+    assert server.file_path_exists('/sys/firmware/efi/')


### PR DESCRIPTION
Add tests in order to test custom images using UEFI firmware type.
- Upload an image with firmware_type=uefi
- Create a server using the uploaded UEFI image

For more information, see [cloudscale.ch List Custom Images API Docs](https://www.cloudscale.ch/en/api/v1#custom-images) --> `firmware_type`.