### PR TITLE
Disable FCOS image testing for the time being

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -43,6 +43,7 @@ COMMON = (
 
 # The following images are excluded from automatic testing
 EXCLUDE = (
+    'fcos',
     'opnsense',
     'pfsense',
 )


### PR DESCRIPTION
This image currently fails regularly, but randomly when being tested. These failures have no bearing on the functioning of our cloud. Since we do watch our acceptance tests closely for regressions found there, we disable these tests, as we investigate further, to avoid noise in our monitoring.