### PR TITLE
Adjust private network and Floating IP stability timings

### DIFF
--- a/test_floating_ip.py
+++ b/test_floating_ip.py
@@ -81,8 +81,8 @@ def test_floating_ip_stability(prober, create_server, server_group,
             # Wait up to 15 seconds for the change to propagate
             prober.ping(floating_ip, timeout=1, tries=15)
 
-            # Expect twenty successful pings in 10 seconds
-            prober.ping(floating_ip, interval=0.5, count=20)
+            # Expect 60 successful pings in 30 seconds
+            prober.ping(floating_ip, interval=0.5, count=60)
 
             # Make sure the DHCP assigned IP still works
             prober.ping(s.ip('public', floating_ip.version))

--- a/test_private_network.py
+++ b/test_private_network.py
@@ -349,7 +349,7 @@ def test_private_network_attach_later(server, private_network):
         assert len(private_addresses) == 1
         assert private_addresses[0] in subnet
 
-    retry_for(seconds=15).or_fail(
+    retry_for(seconds=30).or_fail(
         assert_private_network_is_configured,
         msg='Failed to configure private network.',
     )


### PR DESCRIPTION
As discussed, these adjustments should cause a known false positive to disappear, and a known false negative to appear (should the issue arise).