### PR TITLE
Start tests in prod-rma1 earlier

### DIFF
--- a/.github/workflows/acceptance-tests-in-rma1.yml
+++ b/.github/workflows/acceptance-tests-in-rma1.yml
@@ -13,7 +13,7 @@ on:
 
   # Scheduled tests (UTC)
   schedule:
-    - cron: '0 16 * * *'
+    - cron: '0 15 * * *'
 
   # Manual execution through the UI by collaborators
   workflow_dispatch:


### PR DESCRIPTION
This avoids overlapping tests. Those are less than ideal, as they may skew our timings.