### PR TITLE
Increase robustness of two_servers_in_same_subnet

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -50,7 +50,7 @@ NUMBERS = re.compile(r'[0-9]*\.?[0-9]+')
 SERVER_START_TIMEOUT = 240
 
 # How many resources may be spawned in parallel in a single call
-RESOURCE_CREATION_CONCURRENCY_LIMIT = 4
+RESOURCE_CREATION_CONCURRENCY_LIMIT = 2
 
 # Where events are logged
 EVENTS_PATH = 'events'

--- a/test_public_network.py
+++ b/test_public_network.py
@@ -102,8 +102,8 @@ def test_public_network_port_security(ip_version, two_servers_in_same_subnet):
     Attention: Due to it's nature this test can cause havoc on the network in
     the absence of effective port security to prevent ARP and ND spoofing!
 
-    This is notoriously unreliable in failing in the absence of port security
-    rules for IPv6. It often succeeds even if it should fail.
+    This test can reliably detect port security issues in IPv4, but it is
+    unreliable when it comes to IPv6, where it can produce false positives.
     """
 
     # We need two servers in the same subnet


### PR DESCRIPTION
Includes the following changes:

* Launch more servers to find two matching servers.
* Launch them less aggressively (mostly serialized on the API anyway).
* Do not fail if a server cannot be launched, unless all servers fail.
* Use launch parameters that are easy to adjust in the future.

This also includes the doc change from the reverted merge.