### PR TITLE
Lower the timeout for test_private_network_attach_later

### DIFF
--- a/test_private_network.py
+++ b/test_private_network.py
@@ -349,7 +349,7 @@ def test_private_network_attach_later(server, private_network):
         assert len(private_addresses) == 1
         assert private_addresses[0] in subnet
 
-    retry_for(seconds=60).or_fail(
+    retry_for(seconds=30).or_fail(
         assert_private_network_is_configured,
         msg='Failed to configure private network.',
     )


### PR DESCRIPTION
This timeout has been increased in the past as we were struggling with some scaling issues in the backend. This has been fixed and we should now be able to use a much lower timeout.