### PR TITLE
Test DHCP replies related to DNS settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ These tests are run regularly against our public infrastructure as well as our i
 |                     | [test_private_network_mtu](./test_private_network.py#L244)                       | default  |
 |                     | [test_private_network_only_on_all_images](./test_private_network.py#L302)        | all      |
 |                     | [test_private_network_attach_later](./test_private_network.py#L324)              | default  |
+|                     | [test_private_network_dhcp_dns_replies](./test_private_network.py#L358)          | default  |
 | **Public Network**  | [test_public_ip_address_on_all_images](./test_public_network.py#L22)             | all      |
 |                     | [test_public_network_connectivity_on_all_images](./test_public_network.py#L51)   | all      |
 |                     | [test_public_network_mtu](./test_public_network.py#L70)                          | default  |

--- a/events.py
+++ b/events.py
@@ -434,6 +434,12 @@ track_in_event_log('subnet.create.after', include={
     'dns_servers': 'args.self.dns_servers',
 })
 
+track_in_event_log('subnet.change-dns-servers.after', include={
+    **RESOURCE_ID,
+    **RESULT,
+    'dns_servers': 'args.self.dns_servers',
+})
+
 
 # Keep track of custom images
 track_in_event_log('custom-image.import.after', include={


### PR DESCRIPTION
This ensures we do not send any domain search options:

- `option domain-search`
- `option dhcp6.domain-search`

See `man dhcp-options`.

It also asserts that updates to the DNS servers of the subnet, are reflected in the DHCP replies shortly after.