### PR TITLE
Improve the way we execute tests

### DIFF
--- a/.github/workflows/acceptance-tests-in-lpg1.yml
+++ b/.github/workflows/acceptance-tests-in-lpg1.yml
@@ -1,16 +1,8 @@
+# The dedicated workflow for the whole acceptance test-suite. Only run on
+# schedule or manually, but never with any customization.
 name: Acceptance Tests in LPG1
 
 on:
-  # Tests are only run on a regular schedule, or if they are manually started.
-  #
-  # * Pull requests are disabled because anonymous users could cause resource
-  #   usage in the cloud, causing unintended costs.
-  #
-  # * Changes to the main branch are not tested, as we do that nightly anyway
-  #   and the expectation is that new tests are tested locally, in a more
-  #   explicit and change-specific way.
-  #
-
   # Scheduled tests (UTC)
   schedule:
     - cron: '0 18 * * *'
@@ -20,37 +12,8 @@ on:
 
 jobs:
   acceptance-tests-in-lpg1:
-    runs-on: [self-hosted, lpg1]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run tests
-        env:
-          CLOUDSCALE_API_TOKEN: ${{ secrets.CLOUDSCALE_API_TOKEN }}
-        run: |
-          pytest . --zone=lpg1 -n 2 -v --color=yes --reruns=1
-
-      - name: Upload events log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: events-log
-          path: events
-
-      - name: Cleanup
-        if: always()
-        env:
-          CLOUDSCALE_API_TOKEN: ${{ secrets.CLOUDSCALE_API_TOKEN }}
-        run: invoke cleanup
+    uses: ./.github/workflows/run-acceptance-tests.yml
+    with:
+      zone: lpg1
+    secrets:
+      api_token: ${{ secrets.CLOUDSCALE_API_TOKEN_AT_LPG1 }}

--- a/.github/workflows/acceptance-tests-in-lpg1.yml
+++ b/.github/workflows/acceptance-tests-in-lpg1.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload events log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: events-log
           path: events

--- a/.github/workflows/acceptance-tests-in-rma1.yml
+++ b/.github/workflows/acceptance-tests-in-rma1.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload events log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: events-log
           path: events

--- a/.github/workflows/acceptance-tests-in-rma1.yml
+++ b/.github/workflows/acceptance-tests-in-rma1.yml
@@ -1,16 +1,8 @@
+# The dedicated workflow for the whole acceptance test-suite. Only run on
+# schedule or manually, but never with any customization.
 name: Acceptance Tests in RMA1
 
 on:
-  # Tests are only run on a regular schedule, or if they are manually started.
-  #
-  # * Pull requests are disabled because anonymous users could cause resource
-  #   usage in the cloud, causing unintended costs.
-  #
-  # * Changes to the main branch are not tested, as we do that nightly anyway
-  #   and the expectation is that new tests are tested locally, in a more
-  #   explicit and change-specific way.
-  #
-
   # Scheduled tests (UTC)
   schedule:
     - cron: '0 15 * * *'
@@ -20,37 +12,8 @@ on:
 
 jobs:
   acceptance-tests-in-rma1:
-    runs-on: [self-hosted, rma1]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run tests
-        env:
-          CLOUDSCALE_API_TOKEN: ${{ secrets.CLOUDSCALE_API_TOKEN }}
-        run: |
-          pytest . --zone=rma1 -n 2 -v --color=yes --reruns=1
-
-      - name: Upload events log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: events-log
-          path: events
-
-      - name: Cleanup
-        if: always()
-        env:
-          CLOUDSCALE_API_TOKEN: ${{ secrets.CLOUDSCALE_API_TOKEN }}
-        run: invoke cleanup
+    uses: ./.github/workflows/run-acceptance-tests.yml
+    with:
+      zone: rma1
+    secrets:
+      api_token: ${{ secrets.CLOUDSCALE_API_TOKEN_AT_RMA1 }}

--- a/.github/workflows/custom-acceptance-test.yml
+++ b/.github/workflows/custom-acceptance-test.yml
@@ -1,15 +1,52 @@
 # A custom run workflow for testing
-name: Custom Acceptance Test
-
 run-name: Custom Acceptance Test in ${{ inputs.zone }}
+
+name: Custom Acceptance Test
 
 on:
   # Manual execution through the UI by collaborators
   workflow_dispatch:
+    inputs:
+      zone:
+        description: "Zone to run tests in"
+        required: true
+        type: choice
+        options:
+          - LPG1
+          - RMA1
+      expression:
+        description: "Filter tests by this expression (py.test -k)"
+        default: "test_"
+        type: string
+      path:
+        description: "Search for tests in this file or directory"
+        default: "."
+        type: string
+      count:
+        description: "Run the tests this many times"
+        default: 1
+        type: number
+      reruns:
+        description: "Rerun failed tests this many times"
+        default: 0
+        type: number
+      workers:
+        description: "Use this many workers"
+        default: 2
+        type: number
 
 jobs:
   custom-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    uses: ./.github/workflows/run-acceptance-tests.yml
+    with:
+      zone: '${{ inputs.zone }}'
+      expression: '${{ inputs.expression }}'
+      path: '${{ inputs.path }}'
+      # Yes, fromJSON is how GitHub Actions convert strings to numbers. Not
+      # that these numbers should be strings in the first place, but YAML
+      # templating is hard.
+      count: ${{ fromJSON(inputs.count) }}
+      reruns: ${{ fromJSON(inputs.reruns) }}
+      workers: ${{ fromJSON(inputs.workers) }}
+    secrets:
+      api_token: ${{ secrets.CLOUDSCALE_API_TOKEN_AT_CUSTOM }}

--- a/.github/workflows/implemented-tests-table.yml
+++ b/.github/workflows/implemented-tests-table.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -1,0 +1,73 @@
+name: Acceptance Test Run Implementation
+
+on:
+  # This workflow can only be called from other workflows
+  workflow_call:
+    inputs:
+      zone:
+        type: string
+        required: true
+      expression:
+        type: string
+        default: 'test_'
+      path:
+        type: string
+        default: '.'
+      count:
+        type: number
+        default: 1
+      reruns:
+        type: number
+        default: 1
+      workers:
+        type: number
+        default: 2
+    secrets:
+      api_token:
+        required: true
+
+jobs:
+  acceptance-tests:
+    runs-on:
+      - self-hosted
+      - "${{ inputs.zone }}"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          CLOUDSCALE_API_TOKEN: ${{ secrets.api_token }}
+        run: >
+          pytest "${{ inputs.path || '.' }}"
+          --zone="${{ inputs.zone }}"
+          -n ${{ inputs.workers }}
+          -v
+          --color=yes
+          --reruns=${{ inputs.reruns }}
+          --count=${{ inputs.count }}
+          -k "${{ inputs.expression || 'test_' }}"
+
+      - name: Upload events log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: events-log
+          path: events
+
+      - name: Cleanup
+        if: always()
+        env:
+          CLOUDSCALE_API_TOKEN: ${{ secrets.api_token }}
+        run: invoke cleanup

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           CLOUDSCALE_API_TOKEN: ${{ secrets.api_token }}
         run: >
-          pytest "${{ inputs.path || '.' }}"
+          ./pytest "${{ inputs.path || '.' }}"
           --zone="${{ inputs.zone }}"
           -n ${{ inputs.workers }}
           -v

--- a/conftest.py
+++ b/conftest.py
@@ -308,7 +308,12 @@ def pytest_runtest_logreport(report):
     if report.when == 'setup':
         trigger('test.setup', name=report.nodeid, outcome=report.outcome)
     elif report.when == 'call':
-        trigger('test.call', name=report.nodeid, outcome=report.outcome)
+        trigger(
+            'test.call',
+            name=report.nodeid,
+            outcome=report.outcome,
+            error=report.longreprtext
+        )
     elif report.when == 'teardown':
         trigger('test.teardown', name=report.nodeid, outcome=report.outcome)
     else:

--- a/conftest.py
+++ b/conftest.py
@@ -91,6 +91,7 @@ def pytest_addoption(parser):
         action='store',
         default=random.choice(ZONES),
         choices=ZONES,
+        type=str.lower,
         help="Zone to run the tests in (defaults to a random zone)",
     )
 

--- a/events.py
+++ b/events.py
@@ -206,7 +206,10 @@ def on_test_teardown(name, outcome):
 
 
 track_in_event_log('test.start')
-track_in_event_log('test.call', include={'outcome': 'outcome'})
+track_in_event_log('test.call', include={
+    'outcome': 'outcome',
+    'error': 'error'
+})
 
 
 # Keep track of API requests

--- a/pytest
+++ b/pytest
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+""" Wraps py.test to rerun on failures up to n times.
+
+This is very similar to the pytest-rerunfailures plugin, but has the following
+features that the plugin does not provide:
+
+- Always show the full test output in our output
+- The failed tests are retried at the end of each test run.
+
+Example:
+
+    ./pytest . --reruns=1
+
+Note, this is only meant to be used for our scheduled test suite. You generally
+want to use py.test directly.
+
+"""
+
+import argparse
+import shlex
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument('--reruns', type=int, default=0)
+
+
+def main(reruns: int, args: list[str]) -> int:
+    result = None
+
+    if reruns < 0 or 10 < reruns:
+        print(f"Invalid reruns: {reruns}, expected 0-10")
+        return 1
+
+    for run in range(1, reruns + 2):
+        if run == 1:
+            # Clear the cache of old rerun failures the first time
+            cmd = ('pytest', *args, '--cache-clear')
+        else:
+            # Only run failures in consecutive calls
+            cmd = ('pytest', *args, '--last-failed')
+
+        print(f"Running run #{run}: {shlex.join(cmd)}", flush=True)
+        result = subprocess.run(cmd, check=False)
+
+        # Abort as soon as a run was successful
+        if result.returncode == 0:
+            break
+
+    return result.returncode if result is not None else 1
+
+
+if __name__ == '__main__':
+    known, args = parser.parse_known_args()
+    sys.exit(main(**vars(known), args=args))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ paramiko
 psutil
 pytest
 pytest-repeat
-pytest-rerunfailures
 pytest-testinfra
 pytest-xdist
 requests


### PR DESCRIPTION
This introduces a number of improvements for our acceptance tests:

1. We get rid of GitHub warnings on the action view.
2. We can now run manual tests without influencing scheduled tests.
3. We can now run only certain tests manually (e.g., to verify a new test in a branch).
4. Rerun errors are no longer hidden and tests that just failed are now retried towards the end.
5. The events log now contains the line that caused the error, and the exception, for future reporting.