### PR TITLE
Print a summary after each test execution

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -49,7 +49,10 @@ jobs:
       - name: Run tests
         env:
           CLOUDSCALE_API_TOKEN: ${{ secrets.api_token }}
+        # The ::remove-matcher call ensures that automatic annotations are
+        # not applied to the pytest output. We summarize the output ourselves.
         run: >
+          echo "::remove-matcher owner=python::";
           ./pytest "${{ inputs.path || '.' }}"
           --zone="${{ inputs.zone }}"
           -n ${{ inputs.workers }}
@@ -65,6 +68,12 @@ jobs:
         with:
           name: events-log
           path: events
+
+      - name: Print summary
+        if: always()
+        env:
+          CLOUDSCALE_API_TOKEN: ${{ secrets.api_token }}
+        run: 'invoke summary >> $GITHUB_STEP_SUMMARY'
 
       - name: Cleanup
         if: always()

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,7 @@ from resources import Network
 from resources import Server
 from resources import ServerGroup
 from resources import Volume
+from util import extract_short_error
 from util import global_run_id
 from util import in_parallel
 from util import is_matching_slug
@@ -312,7 +313,8 @@ def pytest_runtest_logreport(report):
             'test.call',
             name=report.nodeid,
             outcome=report.outcome,
-            error=report.longreprtext
+            error=report.longreprtext,
+            short_error=extract_short_error(report.longreprtext),
         )
     elif report.when == 'teardown':
         trigger('test.teardown', name=report.nodeid, outcome=report.outcome)

--- a/events.py
+++ b/events.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import os
 
 from collections import OrderedDict
 from constants import EVENTS_PATH
@@ -116,6 +117,7 @@ def record(event, **attributes):
     record['worker'] = CTX.worker_id
     record['test'] = CTX.current_test
     record['event'] = event
+    record['run'] = int(os.environ.get('TEST_RUN', '1'))
 
     for key in sorted(attributes):
         record[key] = attributes[key]
@@ -208,7 +210,8 @@ def on_test_teardown(name, outcome):
 track_in_event_log('test.start')
 track_in_event_log('test.call', include={
     'outcome': 'outcome',
-    'error': 'error'
+    'error': 'error',
+    'short_error': 'short_error',
 })
 
 

--- a/pytest
+++ b/pytest
@@ -17,6 +17,7 @@ want to use py.test directly.
 """
 
 import argparse
+import os
 import shlex
 import subprocess
 import sys
@@ -41,7 +42,9 @@ def main(reruns: int, args: list[str]) -> int:
             cmd = ('pytest', *args, '--last-failed')
 
         print(f"Running run #{run}: {shlex.join(cmd)}", flush=True)
-        result = subprocess.run(cmd, check=False)
+        result = subprocess.run(cmd, check=False, env={
+            'TEST_RUN': str(run), **os.environ,
+        })
 
         # Abort as soon as a run was successful
         if result.returncode == 0:

--- a/util.py
+++ b/util.py
@@ -752,3 +752,28 @@ def assert_takes_no_longer_than(seconds):
     yield
     took = time.monotonic() - start
     assert took <= seconds, f"{took}s > {seconds}s"
+
+
+def extract_short_error(longrepr):
+    """ Takes a longrepr exception report and extracts the most relevant
+    line from it.
+
+    Since the last exception is the first one to have occurred, and the '>'
+    points to the executed line, followed by error lines, we take the first
+    error line after the '>'.
+
+    """
+
+    if not longrepr:
+        return None
+
+    prev = None
+
+    # Start from the bottom since that's nearer
+    for line in reversed(longrepr.splitlines()):
+        if line.startswith('E'):
+            prev = line
+        if line.startswith('>'):
+            break
+
+    return prev[1:].strip()


### PR DESCRIPTION
This ensures that we have something useful for each GitHub invocation.

See the following run for an example:
https://github.com/cloudscale-ch/acceptance-tests/actions/runs/7915887754

Since this and other runs did complete successfully, here's an example of a local failed run:
https://gist.github.com/href/0c600af5ed6f0bc3cc817a16a83f4fc7

Note: You can click on the errors to get the full traceback.