### PR TITLE
Inrease mass-failover timeout from 30s to 40s

### DIFF
--- a/test_floating_ip.py
+++ b/test_floating_ip.py
@@ -163,14 +163,14 @@ def test_floating_ip_mass_failover(prober, create_server, server_group,
     assert s1.reachable_via_ip(*ips, timeout=15)
 
     # Move the Floating IPs to s2
-    with assert_takes_no_longer_than(seconds=30):
+    with assert_takes_no_longer_than(seconds=40):
         for ip in ips:
             ip.assign(s2)
 
         assert s2.reachable_via_ip(*ips, timeout=15)
 
     # Move the Floating IPs to s1
-    with assert_takes_no_longer_than(seconds=30):
+    with assert_takes_no_longer_than(seconds=40):
         for ip in ips:
             ip.assign(s1)
 


### PR DESCRIPTION
This is not the performance we are aiming for, so we have created an internal ticket to be able to get back to 30s. For now however, 30s is not feasible at all times.