### PR TITLE
Try IPv6 ping longer and more often

### DIFF
--- a/resources.py
+++ b/resources.py
@@ -313,7 +313,7 @@ class Server(CloudscaleResource):
             # address. A DNS lookup is used for it, to not hard-code the
             # address. The DNS lookup is usually done via IPv4 on the host.
             ipv6_address = self.resolve('api.cloudscale.ch', version=6)[0]
-            self.ping(ipv6_address, tries=2, wait=5)
+            self.ping(ipv6_address, tries=10, wait=2)
 
     @with_trigger('server.wait-for-cloud-init')
     def wait_for_cloud_init(self, host, timeout):


### PR DESCRIPTION
Using the log, this allows us to find out how many times each invocation tries until it is able to ping the API via IPv6:

```bash
cat events/*.log \
  | egrep 'ping.+2a06' \
  | jq -r '.worker + " " + .time + " " + .test + " " + .command + " exit_status=" + (.exit_status | tostring)' \
  | sort -k 1,2 \
  | awk '{print $0} /exit_status=0/ { printf "\n" }'
```