### PR TITLE
Fix 503 retry counts not checking for the HTTP code

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -177,7 +177,8 @@ def summary(c):
         if r['outcome'] != 'passed' and r['run'] == maxrun]
 
     maintenance_retries = sum(
-        r['retries'] for r in retries
+        sum(1 for retry in r['history'] if 503 in retry)
+        for r in retries
         if r['event'] == 'request.retry')
 
     print("# Test Run Summary")


### PR DESCRIPTION
Instead, all retries were treated the same, even if the HTTP code was something like say a `400` (which can happen during the course of the test, as some actions are attempted early).