### PR TITLE
Add port 25 block tests

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -225,6 +225,11 @@ def implemented_tests_table(c):
     headers = ['Category', 'Test Name', 'Images']
     rows = []
 
+    # Exclude certain files from the table
+    exclude_list = [
+        'test_infrastructure.py'
+    ]
+
     # Special cases for capitalizing test category titles
     category_capitalization = {
         'floating ip': 'Floating IP',
@@ -232,6 +237,10 @@ def implemented_tests_table(c):
     }
 
     for module_path in sorted(Path('.').glob('test_*.py')):
+        # Exclude certain files from the table
+        if module_path.name in exclude_list:
+            continue
+
         module = importlib.import_module(module_path.stem)
         cat = module_path.stem.replace('test_', '').replace('_', ' ')
         cat = category_capitalization.get(cat, cat.title())

--- a/test_infrastructure.py
+++ b/test_infrastructure.py
@@ -1,0 +1,102 @@
+"""
+
+Infrastructure Functionality
+============================
+
+"""
+
+import pytest
+import time
+
+
+@pytest.mark.parametrize('ip_version', [4, 6])
+def test_outgoing_smtp_block_ip(server, ip_version):
+    """ All outbound SMTP (Port 25) traffic is blocked by default.
+
+    Port 25 outbound is blocked for all IPv4 and IPv6 addresses,
+    but can be enabled for upon request.
+
+    """
+
+    # Get the source IP addresses
+    ip = server.ip('public', ip_version)
+
+    server.run('sudo apt update')
+    server.run('sudo apt install netcat-openbsd -y')
+
+    # Allow up to 1 minute until we expect connections to be blocked
+    until = time.monotonic() + 60
+
+    while time.monotonic() < until:
+        connect_result = server.run(
+            f'nc -vz -{ip_version} -w 5 -s {ip} mail.cloudscale.ch 25'
+        )
+
+        if connect_result.rc == 1:
+            break
+
+        time.sleep(1)
+
+    assert 'Connection refused' in connect_result.stderr \
+        or 'timed out' in connect_result.stderr
+
+
+@pytest.mark.parametrize(
+    "floating_type, ip_version",
+    [
+        ("floating_ipv4", "4"),
+        ("floating_ipv6", "6"),
+        ("floating_network", "6"),
+    ],
+)
+def test_outgoing_smtp_block_floating_ip(
+    server,
+    floating_type,
+    ip_version,
+    floating_ipv4,
+    floating_ipv6,
+    floating_network
+):
+    """ All outbound SMTP (Port 25) traffic is blocked by default.
+
+    Port 25 outbound is blocked for all Floating IPv4 and IPv6
+    addresses and networks, but can be enabled for certain customers
+    upon request.
+
+    """
+
+    # Get the IP
+    floating_map = {
+        "floating_ipv4": floating_ipv4,
+        "floating_ipv6": floating_ipv6,
+        "floating_network": floating_network.network[1],
+    }
+
+    ip = floating_map[floating_type]
+
+    # Assign and configure the Floating IP to the server
+    if floating_type == "floating_network":
+        floating_network.assign(server)
+    else:
+        ip.assign(server)
+
+    server.configure_floating_ip(ip)
+
+    server.run('sudo apt update')
+    server.run('sudo apt install netcat-openbsd -y')
+
+    # Allow up to 1 minute until we expect connections to be blocked
+    until = time.monotonic() + 60
+
+    while time.monotonic() < until:
+        connect_result = server.run(
+            f'nc -vz -{ip_version} -w 5 -s {ip} mail.cloudscale.ch 25'
+        )
+
+        if connect_result.rc == 1:
+            break
+
+        time.sleep(1)
+
+    assert 'Connection refused' in connect_result.stderr \
+        or 'timed out' in connect_result.stderr


### PR DESCRIPTION
Add tests to verify port 25 outgoing is blocked by default.