### PR TITLE
Scope retries more clearly

### DIFF
--- a/api.py
+++ b/api.py
@@ -7,7 +7,7 @@ from constants import LOCKS_PATH
 from constants import PROCESS_ID
 from constants import RUNNER_ID
 from errors import Timeout
-from events import record, trigger
+from events import trigger
 from filelock import FileLock
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
@@ -26,6 +26,33 @@ class CloudscaleHTTPAdapter(HTTPAdapter):
     def send(self, request, *args, **kwargs):
         with self.lock:
             return super().send(request, *args, **kwargs)
+
+
+class RetryStrategy(Retry):
+    """ We retry certain requests using urllib3's Retry class, but we
+    need to be quite explicit about when, in a way that is more complicated
+    than Retry's config approach.
+
+    """
+
+    def is_retry(self, method, status_code, *args, **kwargs) -> bool:
+        """ This method has to decide if a retry should be attempted, it does
+        not need to know how many retries have been done already.
+
+        """
+
+        # DELETE may fail on resources during cleanup, as they may be
+        # still be in the process of being created.
+        if status_code == 400 and method == 'DELETE':
+            return True
+
+        # Maintenances are always retried.
+        if status_code == 503:
+            return True
+
+        # Fallback to the default retry handling otherwise (which supports
+        # the Retry-After header).
+        return super().is_retry(method, status_code, *args, **kwargs)
 
 
 class API(requests.Session):
@@ -54,16 +81,9 @@ class API(requests.Session):
         self.scope = scope
         self.read_only = read_only
 
-        # The API may be in maintenance (HTTP 503) or
-        # DELETE may fail on resources when they are being created,
-        # so we retry those a number of times.
-        #
         # 8 Retries @ 2.5 backoff_factor = 10.6 minutes
-        retry_strategy = Retry(
+        retry_strategy = RetryStrategy(
             total=8,
-            status_forcelist=[400, 503],
-            allowed_methods=["HEAD", "GET", "POST", "DELETE"],
-            raise_on_status=False,  # Prevent Exception after every request
             backoff_factor=2.5
         )
 
@@ -112,14 +132,6 @@ class API(requests.Session):
 
     def on_response(self, response, *args, **kwargs):
         trigger('request.after', request=response.request, response=response)
-
-        # Record the history if Retry was used
-        if response.raw.retries.history:
-            record(
-                'request.retry',
-                retries=len(response.raw.retries.history),
-                history=response.raw.retries.history
-            )
 
         try:
             response.raise_for_status()

--- a/events.py
+++ b/events.py
@@ -224,6 +224,8 @@ track_in_event_log('request.after', include={
     'url': 'request.url',
     'status': 'response.status_code',
     'took': lambda a: a.response.elapsed.total_seconds(),
+    'retries': lambda a: len(a.response.raw.retries.history),
+    'history': lambda a: [r.status for r in a.response.raw.retries.history],
 })
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -130,7 +130,7 @@ def summary(c):
 
     pattern = f'at-{date.today().year}-*.log'
     results = []
-    retries = []
+    requests = []
 
     # Go from newest to oldest, until events with only one run are found. This
     # way, we get the latest events of run n, then n-1, towards 1.
@@ -142,8 +142,8 @@ def summary(c):
                 e = json.loads(line)
 
                 # Collect all request retry events
-                if e['event'] == 'request.retry':
-                    retries.append(e)
+                if e['event'].startswith('request.'):
+                    requests.append(e)
 
                 if e.get('event') not in ('test.setup', 'test.call'):
                     continue
@@ -177,9 +177,9 @@ def summary(c):
         if r['outcome'] != 'passed' and r['run'] == maxrun]
 
     maintenance_retries = sum(
-        sum(1 for retry in r['history'] if 503 in retry)
-        for r in retries
-        if r['event'] == 'request.retry')
+        sum(1 for status in r['history'] if status == 503)
+        for r in requests
+        if r['retries'])
 
     print("# Test Run Summary")
     print("")


### PR DESCRIPTION
- We do not want to retry on HTTP 400, unless it is a DELETE.
- We want to log the retries with the corresponding request.