### PR TITLE
Log request body for failed requests

### DIFF
--- a/api.py
+++ b/api.py
@@ -140,9 +140,6 @@ class API(requests.Session):
                 and e.response.status_code == 404
 
             if not ignore:
-                print(f"{e.request.method} {e.request.url} failed:")
-                print(e.response.text)
-
                 raise e
 
     def request(self, method, url, *args, **kwargs):

--- a/events.py
+++ b/events.py
@@ -223,6 +223,8 @@ track_in_event_log('request.after', include={
     'event': lambda a: f'request.{a.request.method}',
     'url': 'request.url',
     'status': 'response.status_code',
+    'body': lambda a: a.response.text if not a.response.ok
+    else '<suppressed>',
     'took': lambda a: a.response.elapsed.total_seconds(),
     'retries': lambda a: len(a.response.raw.retries.history),
     'history': lambda a: [r.status for r in a.response.raw.retries.history],


### PR DESCRIPTION
Log the request body to the event log for failed requests. This often contains a more detailed error message. Successful request bodies are not logged. They may contain sensitive information and are generally much larger.

This removes the "print" logging which was done before. This was the only part of the code which logged using print to standard output.