### PR TITLE
Support Debian 13 (Trixie) and Make It The Default

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -72,7 +72,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--default-image',
         action='store',
-        default='debian-12',
+        default='debian-13',
         help='Default image slug to use for tests',
     )
 
@@ -423,7 +423,7 @@ def prober(create_server_for_session):
     """ Server acting as a jump-host for servers without public IP address. """
 
     return create_server_for_session(
-        image='debian-12', use_private_network=True)
+        image='debian-13', use_private_network=True)
 
 
 @pytest.fixture(scope='function')

--- a/resources.py
+++ b/resources.py
@@ -593,8 +593,15 @@ class Server(CloudscaleResource):
         else:
             address = ip
 
-        key = self.output_of(
+        output = self.output_of(
             f'ssh-keyscan -t ed25519 {address} | cut -d " " -f 2-3')
+
+        key = next(
+            (
+                line for line in output.splitlines()
+                if line.startswith('ssh-ed25519')
+            ), None
+        )
 
         if not key:
             return None

--- a/resources.py
+++ b/resources.py
@@ -1,3 +1,4 @@
+import re
 import secrets
 import textwrap
 import tempfile
@@ -365,10 +366,15 @@ class Server(CloudscaleResource):
     def wait_for_ipv6_default_route(self, timeout=30):
         until = datetime.utcnow() + timedelta(seconds=timeout)
 
+        # Match the legacy output, as well as the more modern next-hop id way:
+        # - modern: default nhid 0123456789 via fe80::1 dev
+        # - legacy: default via fe80::1
+        route = re.compile(r'(default nhid \w+|default) via fe80::1 dev')
+
         while datetime.utcnow() <= until:
             ipv6_routes = self.output_of('sudo ip -6 route')
 
-            if 'default via fe80::1 dev' in ipv6_routes:
+            if route.search(ipv6_routes):
                 return
 
             time.sleep(1)

--- a/scripts/lbaas-http-test-server
+++ b/scripts/lbaas-http-test-server
@@ -176,9 +176,7 @@ with http.server.ThreadingHTTPServer(
     print(f'LBaaS test HTTP server running on '
           f'{":".join(map(str, server.server_address))}')
     if args.ssl:
-        server.socket = ssl.wrap_socket(
-            server.socket,
-            certfile='./server.pem',
-            server_side=True,
-        )
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.load_cert_chain('./server.pem')
+        server.socket = context.wrap_socket(server.socket, server_side=True)
     server.serve_forever()

--- a/test_nested_virtualization.py
+++ b/test_nested_virtualization.py
@@ -56,7 +56,7 @@ def test_run_nested_vm(server):
     # Make sure qemu tests pass and rc == 0
     assert server.output_of('sudo virt-host-validate --help')
 
-    server.run(f'wget {vm_iso_url}')
+    server.run(f'wget {vm_iso_url} -O /var/tmp/{vm_os}.qcow2')
     server.run('sudo virsh net-start default')
     server.run('sudo virsh net-autostart default')
 
@@ -66,7 +66,7 @@ def test_run_nested_vm(server):
             --name {vm_os}_vm
             --ram 1024
             --vcpus=1
-            --disk path={vm_os}.qcow2,format=qcow2,bus=virtio
+            --disk path=/var/tmp/{vm_os}.qcow2,format=qcow2,bus=virtio
             --autoconsole none
             --os-variant generic
             --hvm

--- a/test_private_network.py
+++ b/test_private_network.py
@@ -421,6 +421,9 @@ def test_private_network_dhcp_dns_replies(server, private_network):
 
     assert server.private_interface.exists
 
+    server.assert_run('sudo apt-get update')
+    server.assert_run('sudo apt-get install -y isc-dhcp-client')
+
     # No DHCP reply sets a search domain
     reply = server.dhcp_reply(server.public_interface.name, ip_version=4)
     assert "domain-search" not in reply

--- a/test_volume.py
+++ b/test_volume.py
@@ -332,7 +332,7 @@ def test_snapshot_root_volume(create_server):
 
     """
 
-    server = create_server(image='debian-12')
+    server = create_server(image='debian-13')
     volume = server.root_volume
 
     # Sync everything written during boot to disk (eg. SSH host keys)


### PR DESCRIPTION
See individual commits for reasoning of the various changes. With these, all tests pass with both `debian-12` and `debian-13` as default image.