### PR TITLE
Fix and unifiy all access to custom images

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ These tests are run regularly against our public infrastructure as well as our i
 |                           | [test_frontend_allowed_cidr](./test_load_balancer.py#L737)                       | default  |
 |                           | [test_proxy_protocol](./test_load_balancer.py#L812)                              | default  |
 |                           | [test_ping](./test_load_balancer.py#L855)                                        | default  |
-| **Nested Virtualization** | [test_virtualization_support](./test_nested_virtualization.py#L13)               | default  |
-|                           | [test_run_nested_vm](./test_nested_virtualization.py#L39)                        | default  |
+| **Nested Virtualization** | [test_virtualization_support](./test_nested_virtualization.py#L14)               | default  |
+|                           | [test_run_nested_vm](./test_nested_virtualization.py#L40)                        | default  |
 | **Private Network**       | [test_private_ip_address_on_all_images](./test_private_network.py#L14)           | all      |
 |                           | [test_private_network_connectivity_on_all_images](./test_private_network.py#L35) | all      |
 |                           | [test_multiple_private_network_interfaces](./test_private_network.py#L88)        | default  |

--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,8 @@ from api import API
 from constants import API_URL
 from constants import LOCKS_PATH
 from constants import RUNNER_ID
+from constants import CUSTOM_IMAGE_ALPINE_URL
+from constants import CUSTOM_IMAGE_DEBIAN_URL
 from datetime import datetime
 from datetime import timedelta
 from events import trigger
@@ -22,7 +24,6 @@ from resources import Network
 from resources import Server
 from resources import ServerGroup
 from resources import Volume
-from urllib.parse import urlparse
 from util import extract_short_error
 from util import global_run_id
 from util import in_parallel
@@ -626,47 +627,25 @@ def private_network(create_private_network):
     return create_private_network()
 
 
-@pytest.fixture(scope='session')
-def custom_image_prefix():
-    """ The prefix to use for custom images stored in S3. """
-
-    host = urlparse(API_URL).netloc
-
-    if host == 'api.cloudscale.ch':
-        return 'prod'
-
-    return host.split('.', 1)[0].split('-')[0]
-
-
 @pytest.fixture(scope='session', params=['raw', 'qcow2', 'iso'])
-def custom_alpine_image(request, upload_custom_image, custom_image_prefix):
+def custom_alpine_image(request, upload_custom_image):
     """ A session scoped custom Alpine image. """
-
-    host = 'https://at-images.objects.lpg.cloudscale.ch'
-    path = f'{custom_image_prefix}/alpine'
 
     return upload_custom_image(
         img_name='Alpine',
-        img=f'{host}/{path}',
+        img=CUSTOM_IMAGE_ALPINE_URL,
         firmware_type='bios',
         fmt=request.param
     )
 
 
 @pytest.fixture(scope='session', params=['raw', 'qcow2'])
-def custom_debian_uefi_image(
-    request,
-    upload_custom_image,
-    custom_image_prefix,
-):
+def custom_debian_uefi_image(request, upload_custom_image):
     """ A session scoped custom Debian UEFI image. """
-
-    host = 'https://at-images.objects.lpg.cloudscale.ch'
-    path = f'{custom_image_prefix}/debian'
 
     return upload_custom_image(
         img_name='Debian UEFI',
-        img=f'{host}/{path}',
+        img=CUSTOM_IMAGE_DEBIAN_URL,
         firmware_type='uefi',
         fmt=request.param
     )

--- a/constants.py
+++ b/constants.py
@@ -30,6 +30,35 @@ PUBLIC_PING_TARGETS = {
     6: '2001:4860:4860::8888'
 }
 
+# Custom images for tests. Each image comes in the following formats (appended
+# to the CUSTOM_IMAGE_<IMAGE>_URL variable as extension:
+#
+# - qcow2
+# - raw
+# - iso
+#
+# For example:
+#
+#   https://at-images.objects.lpg.cloudscale.ch/prod/alpine.qcow2
+#
+# Each format further has the following hash sums, each of which refers to the
+# hash that OpenStack sees after import (in the case of qcow2, this is the same
+# hash as the raw image, as qcow2 is first converted to raw):
+#
+# - md5
+# - sha256
+#
+# For exmple:
+#
+#   https://at-images.objects.lpg.cloudscale.ch/prod/alpine.sha256
+#
+# Note: These images are built for testing and not meant for anything else.
+#
+CUSTOM_IMAGE_PREFIX = re.search('/(|[a-z]+)-?api', API_URL).group(1) or 'prod'
+CUSTOM_IMAGE_BASE = f'https://at-images.objects.lpg.cloudscale.ch'
+CUSTOM_IMAGE_ALPINE_URL = f'{CUSTOM_IMAGE_BASE}/{CUSTOM_IMAGE_PREFIX}/alpine'
+CUSTOM_IMAGE_DEBIAN_URL = f'{CUSTOM_IMAGE_BASE}/{CUSTOM_IMAGE_PREFIX}/debian'
+
 # Unique id that distinguishes acceptance tests generated resources.
 RUNNER_ID_HASH = blake2b(API_TOKEN.encode("utf-8"), digest_size=8).hexdigest()
 RUNNER_ID = f'at-{RUNNER_ID_HASH}'

--- a/test_nested_virtualization.py
+++ b/test_nested_virtualization.py
@@ -7,6 +7,7 @@ Customers can start virtual servers inside VMs (nested virtualiziation).
 
 """
 
+from constants import CUSTOM_IMAGE_ALPINE_URL
 from util import oneliner
 
 
@@ -40,7 +41,7 @@ def test_run_nested_vm(server):
     """ Nested virtualization is supported. """
 
     vm_os = 'alpine'   # Needs to match one virt os-variant
-    vm_iso_url = 'https://at-images.objects.lpg.cloudscale.ch/alpine.qcow2'
+    vm_iso_url = f"{CUSTOM_IMAGE_ALPINE_URL}.qcow2"
 
     # Install the required package
     server.run('sudo apt update')


### PR DESCRIPTION
With the recent image URL changes, one test was overlooked. To avoid a repeat in the future, this commit unifies all custom image URLs into shared constants.