### PR TITLE
Update pre-flight to reflect new minimum Python requirement

### DIFF
--- a/pre-flight
+++ b/pre-flight
@@ -62,12 +62,12 @@ function is-supported-python() {
     minor="$(python3 -c 'import sys; print(sys.version_info[1])')"
 
     if (( major < 3 )); then
-        echo "Python $major.$minor is too old, please use 3.6+"
+        echo "Python $major.$minor is too old, please use >= 3.11"
         false; return
     fi
 
-    if (( minor < 6 )); then
-        echo "Python $major.$minor is too old, please use 3.6+"
+    if (( minor < 11 )); then
+        echo "Python $major.$minor is too old, please use >= 3.11"
         false; return
     fi
 


### PR DESCRIPTION
With `datetime` only bringing `UTC` in `3.11`, bump the minimum required Python version to >= 3.11